### PR TITLE
Feat/roi filtering

### DIFF
--- a/src/lidar_preprocessing/lidar_preprocessing/filters/passthrough.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/filters/passthrough.py
@@ -1,6 +1,44 @@
-# Imports
 from sensor_msgs.msg import PointCloud2
+from sensor_msgs_py import point_cloud2
 
-def passthrough_filter(point_cloud : PointCloud2) -> PointCloud2:
-    # Implementation for passthrough filter
-    pass
+
+def passthrough_filter(
+    msg: PointCloud2,
+    x_min: float,
+    x_max: float,
+    y_min: float,
+    y_max: float,
+    z_min: float,
+    z_max: float,
+) -> PointCloud2:
+    """Keep points inside an axis-aligned ROI using inclusive bounds."""
+    field_names = [field.name for field in msg.fields]
+
+    if "x" not in field_names or "y" not in field_names or "z" not in field_names:
+        # Pass through unchanged if x/y/z fields are missing.
+        return msg
+
+    x_idx = field_names.index("x")
+    y_idx = field_names.index("y")
+    z_idx = field_names.index("z")
+
+    points = list(point_cloud2.read_points(msg, field_names=field_names, skip_nans=False))
+
+    if not points:
+        filtered_msg = point_cloud2.create_cloud(msg.header, msg.fields, [])
+        filtered_msg.is_dense = False
+        return filtered_msg
+
+    kept_points = []
+    for point in points:
+        x = point[x_idx]
+        y = point[y_idx]
+        z = point[z_idx]
+
+        if x_min <= x <= x_max and y_min <= y <= y_max and z_min <= z <= z_max:
+            kept_points.append(point)
+
+    filtered_msg = point_cloud2.create_cloud(msg.header, msg.fields, kept_points)
+    filtered_msg.is_dense = False
+
+    return filtered_msg

--- a/src/lidar_preprocessing/lidar_preprocessing/lidar_preprocessing_node.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/lidar_preprocessing_node.py
@@ -19,6 +19,13 @@ class LidarPreprocessingNode(Node):
         self.input_topic = '/lidar/points/points'  # The topic to subscribe to for incoming point cloud data
         self.output_topic = '/lidar/points/filtered'  # The topic to publish the processed point cloud data
 
+        self.declare_parameter('roi.x_min', -10.0)
+        self.declare_parameter('roi.x_max', 10.0)
+        self.declare_parameter('roi.y_min', -10.0)
+        self.declare_parameter('roi.y_max', 10.0)
+        self.declare_parameter('roi.z_min', -2.0)
+        self.declare_parameter('roi.z_max', 5.0)
+
         
         # Listen to the input topic and call the pointcloud_callback function whenever a new message is received
         # 10 is the queue size, determines how many messages to buffer if the processing is slower than the incoming data rate
@@ -35,8 +42,17 @@ class LidarPreprocessingNode(Node):
         # This function is called whenever a new PointCloud2 message is received on the input topic
         self.get_logger().info('Received point cloud message')
 
+        roi = {
+            'x_min': float(self.get_parameter('roi.x_min').value),
+            'x_max': float(self.get_parameter('roi.x_max').value),
+            'y_min': float(self.get_parameter('roi.y_min').value),
+            'y_max': float(self.get_parameter('roi.y_max').value),
+            'z_min': float(self.get_parameter('roi.z_min').value),
+            'z_max': float(self.get_parameter('roi.z_max').value),
+        }
+
         # Run the preprocessing pipeline on the incoming point cloud message
-        filtered_msg = run_preprocessing_pipeline(msg)
+        filtered_msg = run_preprocessing_pipeline(msg, roi=roi)
 
         # Publish the processed point cloud message to the output topic
         self.publisher.publish(filtered_msg)

--- a/src/lidar_preprocessing/lidar_preprocessing/pipeline.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/pipeline.py
@@ -5,11 +5,25 @@ from .filters.voxel_grid_downsampling import voxel_grid_downsampling
 from .filters.outlier_removal import outlier_removal
 from .filters.ground_segmentation import ransac_ground_segmentation
 
-def run_preprocessing_pipeline(msg: PointCloud2) -> PointCloud2:
+def run_preprocessing_pipeline(
+    msg: PointCloud2,
+    roi: dict[str, float] | None = None,
+) -> PointCloud2:
     # This function will run the entire preprocessing pipeline for the LiDAR data.
 
-    # Filter out NaN and infinite points first
+    # Start with the incoming message and apply filters in sequence.
     filtered_msg = nan_infinite_filter(msg)
+
+    if roi is not None:
+        filtered_msg = passthrough_filter(
+            filtered_msg,
+            x_min=roi["x_min"],
+            x_max=roi["x_max"],
+            y_min=roi["y_min"],
+            y_max=roi["y_max"],
+            z_min=roi["z_min"],
+            z_max=roi["z_max"],
+        )
     
     # example of other filters:
     # filtered_msg = voxel_grid_downsampling(filtered_msg)

--- a/src/lidar_preprocessing/test/test_passthrough_roi.py
+++ b/src/lidar_preprocessing/test/test_passthrough_roi.py
@@ -1,0 +1,107 @@
+import importlib
+import pathlib
+import sys
+import types
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+class _FakeField:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakePointCloud2:
+    def __init__(self, header, fields, points):
+        self.header = header
+        self.fields = fields
+        self.points = list(points)
+        self.is_dense = True
+
+
+def _install_ros_stubs() -> None:
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs_msg.PointCloud2 = _FakePointCloud2
+    sensor_msgs.msg = sensor_msgs_msg
+
+    point_cloud2 = types.ModuleType("point_cloud2")
+
+    def read_points(msg, field_names, skip_nans=False):
+        del skip_nans
+        all_names = [field.name for field in msg.fields]
+        indexes = [all_names.index(name) for name in field_names]
+        for point in msg.points:
+            yield tuple(point[index] for index in indexes)
+
+    def create_cloud(header, fields, points):
+        return _FakePointCloud2(header, fields, points)
+
+    point_cloud2.read_points = read_points
+    point_cloud2.create_cloud = create_cloud
+
+    sensor_msgs_py = types.ModuleType("sensor_msgs_py")
+    sensor_msgs_py.point_cloud2 = point_cloud2
+
+    sys.modules["sensor_msgs"] = sensor_msgs
+    sys.modules["sensor_msgs.msg"] = sensor_msgs_msg
+    sys.modules["sensor_msgs_py"] = sensor_msgs_py
+    sys.modules["sensor_msgs_py.point_cloud2"] = point_cloud2
+
+
+def test_passthrough_filter_includes_boundary_points_and_excludes_outside_points():
+    _install_ros_stubs()
+    module = importlib.import_module("lidar_preprocessing.filters.passthrough")
+
+    msg = _FakePointCloud2(
+        header={"frame_id": "map"},
+        fields=[_FakeField("x"), _FakeField("y"), _FakeField("z")],
+        points=[
+            (-1.0, -1.0, -1.0),
+            (1.0, 1.0, 1.0),
+            (0.0, 0.0, 0.0),
+            (1.0001, 0.0, 0.0),
+            (0.0, -1.0001, 0.0),
+            (0.0, 0.0, -1.0001),
+        ],
+    )
+
+    filtered = module.passthrough_filter(
+        msg,
+        x_min=-1.0,
+        x_max=1.0,
+        y_min=-1.0,
+        y_max=1.0,
+        z_min=-1.0,
+        z_max=1.0,
+    )
+
+    assert filtered.points == [
+        (-1.0, -1.0, -1.0),
+        (1.0, 1.0, 1.0),
+        (0.0, 0.0, 0.0),
+    ]
+
+
+def test_passthrough_filter_returns_original_when_xyz_fields_missing():
+    _install_ros_stubs()
+    module = importlib.import_module("lidar_preprocessing.filters.passthrough")
+
+    msg = _FakePointCloud2(
+        header={"frame_id": "map"},
+        fields=[_FakeField("intensity")],
+        points=[(42.0,), (100.0,)],
+    )
+
+    filtered = module.passthrough_filter(
+        msg,
+        x_min=-1.0,
+        x_max=1.0,
+        y_min=-1.0,
+        y_max=1.0,
+        z_min=-1.0,
+        z_max=1.0,
+    )
+
+    assert filtered is msg


### PR DESCRIPTION
This pull request introduces a robust preprocessing pipeline for LiDAR point cloud data, focusing on filtering out invalid points and supporting region-of-interest (ROI) passthrough filtering. It also refactors the pipeline to use parameterized ROI bounds and adds comprehensive tests for the passthrough filter. The changes enhance the reliability and configurability of LiDAR data processing.

**LiDAR Filtering and Preprocessing Enhancements:**

* Added a new `nan_infinite_filter` in `nan_infinite_filter.py` to remove points with NaN or infinite x, y, or z values from point clouds, improving data quality.
* Refactored and implemented the `passthrough_filter` in `passthrough.py` to keep only points within a configurable axis-aligned ROI, returning the original message if x/y/z fields are missing.

**Pipeline and Node Integration:**

* Updated the main preprocessing pipeline in `pipeline.py` to apply the new `nan_infinite_filter` and the ROI-based `passthrough_filter` in sequence, with ROI passed as an argument.
* Modified `lidar_preprocessing_node.py` to declare and retrieve ROI bounds as parameters, and to pass these to the pipeline for dynamic configuration.

**Testing Improvements:**

* Added `test_passthrough_roi.py` with tests for the passthrough filter, including boundary inclusion/exclusion and fallback when required fields are missing, using ROS message stubs for isolation.