### PR TITLE
Prepare Open3D for Installation.

### DIFF
--- a/src/lidar_preprocessing/package.xml
+++ b/src/lidar_preprocessing/package.xml
@@ -15,6 +15,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <depend>open3d</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/lidar_preprocessing/setup.py
+++ b/src/lidar_preprocessing/setup.py
@@ -11,7 +11,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
-    install_requires=['setuptools', 'numpy'],
+    install_requires=['setuptools', 'numpy', 'open3d'],
     zip_safe=True,
     maintainer='brian',
     maintainer_email='brianyariel.rm@gmail.com',

--- a/src/lidar_preprocessing/test/test_open3d.py
+++ b/src/lidar_preprocessing/test/test_open3d.py
@@ -1,0 +1,12 @@
+import open3d as o3d
+
+def test_open3d_version():
+    """
+    Test to ensure open3d is installed and accessible.
+    This test will print the version of the open3d library.
+    """
+    print(f"Successfully imported open3d version: {o3d.__version__}")
+    assert o3d.__version__ is not None
+
+if __name__ == '__main__':
+    test_open3d_version()


### PR DESCRIPTION
Before starting to work on the issue #29  , I wanted to make sure my Landing Team had Open3D installed. To do this, I modified the `setup.py` and `package.xml files`. I've included a` test_open3d.py` file so you can verify if you were able to install **Open3D** correctly.