### PR TITLE
Add ground and obstacle point cloud topics to preprocessing node

### DIFF
--- a/src/lidar_preprocessing/lidar_preprocessing/lidar_preprocessing_node.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/lidar_preprocessing_node.py
@@ -7,7 +7,7 @@ from rclpy.node import Node
 # This imports the PointCloud2 message type, which is used to represent 3D point cloud data.
 from sensor_msgs.msg import PointCloud2
 
-from .pipeline import run_preprocessing_pipeline_with_stats
+from .pipeline import run_preprocessing_pipeline_with_stats, run_preprocessing_pipeline
 
 
 class LidarPreprocessingNode(Node):
@@ -32,6 +32,16 @@ class LidarPreprocessingNode(Node):
         self.declare_parameter('outlier.mean_k', 50)
         self.declare_parameter('outlier.threshold', 3.0)
 
+        self.ground_topic = '/lidar/points/ground'
+        self.obstacles_topic = '/lidar/points/obstacles'
+
+        self.declare_parameter('roi.x_min', -10.0)
+        self.declare_parameter('roi.x_max', 10.0)
+        self.declare_parameter('roi.y_min', -10.0)
+        self.declare_parameter('roi.y_max', 10.0)
+        self.declare_parameter('roi.z_min', -2.0)
+        self.declare_parameter('roi.z_max', 5.0)
+
         # Listen to the input topic and call the pointcloud_callback function whenever a new message is received
         # 10 is the queue size, determines how many messages to buffer if the processing is slower than the incoming data rate
         self.subscription = self.create_subscription(
@@ -47,9 +57,24 @@ class LidarPreprocessingNode(Node):
             10
         )
 
+        self.ground_publisher = self.create_publisher(
+            PointCloud2,
+            self.ground_topic,
+            10
+        )
+
+        self.obstacles_publisher = self.create_publisher(
+            PointCloud2,
+            self.obstacles_topic,
+            10
+        )
+
         # Log the topics we are subscribing to and publishing to
         self.get_logger().info(f'Subscribed to {self.input_topic}')
         self.get_logger().info(f'Publishing to {self.output_topic}')
+
+        self.get_logger().info(f'Publishing ground to {self.ground_topic}')
+        self.get_logger().info(f'Publishing obstacles to {self.obstacles_topic}')
 
     def pointcloud_callback(self, msg: PointCloud2):
         roi = {
@@ -60,6 +85,7 @@ class LidarPreprocessingNode(Node):
             'z_min': float(self.get_parameter('roi.z_min').value),
             'z_max': float(self.get_parameter('roi.z_max').value),
         }
+
 
         enable_nan = bool(self.get_parameter('filters.enable_nan').value)
         enable_voxel = bool(self.get_parameter('filters.enable_voxel').value)
@@ -82,6 +108,9 @@ class LidarPreprocessingNode(Node):
             outlier_mean_k=outlier_mean_k,
             outlier_threshold=outlier_threshold,
         )
+
+        # Run the preprocessing pipeline on the incoming point cloud message
+        filtered_msg, ground_msg, obstacles_msg = run_preprocessing_pipeline(msg, roi=roi)
 
         # Calculate points after filtering
         num_points_before = stage_counts['raw_input']
@@ -114,7 +143,8 @@ class LidarPreprocessingNode(Node):
 
         # Publish the processed point cloud message to the output topic
         self.publisher.publish(filtered_msg)
-
+        self.ground_publisher.publish(ground_msg)
+        self.obstacles_publisher.publish(obstacles_msg)
 
 def main(args=None):
     rclpy.init(args=args)  # Initialize the ROS2 Python client library

--- a/src/lidar_preprocessing/lidar_preprocessing/pipeline.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/pipeline.py
@@ -47,6 +47,7 @@ def run_preprocessing_pipeline_with_stats(
             z_min=roi["z_min"],
             z_max=roi["z_max"],
         )
+
     stage_counts["after_roi_filtering"] = _count_points(filtered_msg)
 
     if enable_outlier_filter:
@@ -59,18 +60,18 @@ def run_preprocessing_pipeline_with_stats(
 
     return filtered_msg, stage_counts
 
-
 def run_preprocessing_pipeline(
-    msg: PointCloud2,
-    roi: dict[str, float] | None = None,
-    voxel_size: float = 0.1,
-    enable_nan_filter: bool = True,
-    enable_voxel_filter: bool = True,
-    enable_roi_filter: bool = True,
-    enable_outlier_filter: bool = True,
-    outlier_mean_k: int = 30,
-    outlier_threshold: float = 2.0,
-) -> PointCloud2:
+        msg: PointCloud2,
+        roi: dict[str, float] | None = None,
+        voxel_size: float = 0.1,
+        enable_nan_filter: bool = True,
+        enable_voxel_filter: bool = True,
+        enable_roi_filter: bool = True,
+        enable_outlier_filter: bool = True,
+        outlier_mean_k: int = 30,
+        outlier_threshold: float = 2.0,
+    ) -> tuple[PointCloud2, PointCloud2, PointCloud2]:
+
     # Backward-compatible API that returns only the filtered cloud.
     filtered_msg, _ = run_preprocessing_pipeline_with_stats(
         msg,
@@ -84,4 +85,6 @@ def run_preprocessing_pipeline(
         outlier_threshold=outlier_threshold,
     )
 
-    return filtered_msg
+    ground_msg, obstacles_msg = ransac_ground_segmentation(filtered_msg)
+
+    return filtered_msg, ground_msg, obstacles_msg


### PR DESCRIPTION
This PR adds two new topics: /lidar/points/ground and /lidar/points/obstacles.

Updated the preprocessing node to publish:
- filtered point cloud
- ground points
- obstacle points

Pipeline updated to return the additional outputs.

Testing:
After running the preprocessing node I made sure the topics were being published.
<img width="2168" height="192" alt="image" src="https://github.com/user-attachments/assets/e24bcc15-d594-4916-8c7e-8c5c5ee8d69b" />
By checking the ros2 topic I made sure the topics were created.
<img width="828" height="308" alt="image" src="https://github.com/user-attachments/assets/2c556ab9-a919-4a7f-96c0-af62a9361367" />