### PR TITLE
Updated SOR filter & filters parameters.

### DIFF
--- a/src/lidar_preprocessing/lidar_preprocessing/filters/outlier_removal.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/filters/outlier_removal.py
@@ -2,24 +2,24 @@
 from sensor_msgs.msg import PointCloud2
 from sensor_msgs_py import point_cloud2
 import numpy as np
+from scipy.spatial import cKDTree
 
 def statistical_outlier_removal(point_cloud : PointCloud2, meanK=30, threshold=2) -> PointCloud2:
     """
-    Removes points that are too far away from its neighbors.
-    Time Complexity: O(n^2)
+    Removes points that are far from their neighboring points using Statistical Outlier Removal (SOR).
+
+    Time Complexity: O(nlogn)
 
     Args:
-        point_cloud (PointCloud2): The cloud of points which will be filtered.
-        meank (int): number of neighbors to analyze
-        threshold (float): standard deviation threshold, how strict the filter is.
-            - Small: removes more points
-            - Large: removes less points
+        point_cloud (PointCloud2): Input point cloud to filter.
+        meanK (int): Number of nearest neighbors used to compute the averagedistance for each point.
+        threshold (float): Standard deviation multiplier used to decide outliers.
+            - Smaller value: removes more points.
+            - Larger value: removes fewer points.
 
     Returns:
-        PointCloud2: The filtered pointcloud.    
+        PointCloud2: Filtered point cloud with statistical outliers removed.
 
-    Note: This python version is fine as a prototype, but is O(n^2) because it builds all pairwise distances. 
-          For a dense LiDAR point cloud, it can get slow. Reason why native PCL/C++ is better long term.
     """
 
     field_names = ("x", "y", "z")
@@ -36,38 +36,26 @@ def statistical_outlier_removal(point_cloud : PointCloud2, meanK=30, threshold=2
     if len(points) <= meanK:
         return point_cloud
     
-     # Array to store average distance to the k nearest neighbors for each point
-    average_distances = np.empty(len(points), dtype=np.float32)
+    # Build KDTree for fast nearest-neighbor search
+    tree = cKDTree(points)
+    
+    # Query meanK + 1 because the nearest neighbor is the point itself
+    distances, _ = tree.query(points, k=meanK + 1)
 
-    for i in range(len(points)):
-        current_point = points[i]
+    # Remove distance to itself, which is column 0
+    neighbor_distances = distances[:, 1:]
 
-        # Compute distance from current point to every other point
-        # np.linalg.norm(...,axis=1) computes the length of each vector, which is the Euclidean distance.
-        distances = np.linalg.norm(points - current_point, axis=1)
+    average_distances = np.mean(neighbor_distances, axis=1)
 
-        # Ignore distance from the point to itself
-        distances[i] = np.inf
-
-        # Get the k nearest distances without fully sorting
-        nearest_distances = np.partition(distances, meanK)[:meanK]
-
-        # Get the distances to the k nearest neighbors
-        average_distances[i] = np.mean(nearest_distances)
-
-    # Compute global mean and standard deviation
     global_mean = np.mean(average_distances)
     global_std = np.std(average_distances)
 
-    # Points above this threshold are considrered outliers
-    new_threshold = global_mean + (threshold * global_std)
+    distance_limit = global_mean + threshold * global_std
 
-    # Keep only points whose average distance is below the threshold
-    mask = average_distances <= new_threshold
-    filtered_cloud = points[mask]
+    mask = average_distances <= distance_limit
+    filtered_points = points[mask]
 
-    # Convert filtered points back into a PointCloud2 message
-    filtered_msg = point_cloud2.create_cloud_xyz32(point_cloud.header, filtered_cloud.tolist())
-
-    return filtered_msg
-
+    return point_cloud2.create_cloud_xyz32(
+        point_cloud.header,
+        filtered_points.tolist()
+    )

--- a/src/lidar_preprocessing/lidar_preprocessing/lidar_preprocessing_node.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/lidar_preprocessing_node.py
@@ -35,9 +35,10 @@ class LidarPreprocessingNode(Node):
         self.declare_parameter('filters.enable_voxel', True)
         self.declare_parameter('filters.enable_roi', True)
         self.declare_parameter('filters.enable_outlier', True)
+        self.declare_parameter('filters.enable_ransac', True)
 
         # Algorithm Parameters
-        self.declare_parameter('voxel.size', 0.1)
+        self.declare_parameter('voxel.size', 0.03)
         self.declare_parameter('outlier.mean_k', 50)
         self.declare_parameter('outlier.threshold', 3.0)
         self.declare_parameter('ransac.dist_threshold', 0.2)
@@ -88,6 +89,7 @@ class LidarPreprocessingNode(Node):
             enable_voxel_filter=bool(self.get_parameter('filters.enable_voxel').value),
             enable_roi_filter=bool(self.get_parameter('filters.enable_roi').value),
             enable_outlier_filter=bool(self.get_parameter('filters.enable_outlier').value),
+            enable_ransac=bool(self.get_parameter('filters.enable_ransac').value),
             outlier_mean_k=int(self.get_parameter('outlier.mean_k').value),
             outlier_threshold=float(self.get_parameter('outlier.threshold').value),
         )

--- a/src/lidar_preprocessing/lidar_preprocessing/pipeline.py
+++ b/src/lidar_preprocessing/lidar_preprocessing/pipeline.py
@@ -14,11 +14,12 @@ def run_preprocessing_pipeline_with_stats(
     msg: PointCloud2,
     roi: dict[str, float] | None = None,
     ransac_params: dict[str, float] | None = None,
-    voxel_size: float = 0.1,
+    voxel_size: float = 0.03,
     enable_nan_filter: bool = True,
     enable_voxel_filter: bool = True,
     enable_roi_filter: bool = True,
     enable_outlier_filter: bool = True,
+    enable_ransac: bool = True,
     outlier_mean_k: int = 30,
     outlier_threshold: float = 2.0,
 ) -> tuple[PointCloud2, PointCloud2, PointCloud2, dict[str, int]]:
@@ -60,14 +61,18 @@ def run_preprocessing_pipeline_with_stats(
     stage_counts["after_statistical_outlier"] = _count_points(filtered_msg)
 
     # 3. Ground Segmentation (RANSAC)
-    if ransac_params is None:
-        ransac_params = {'dist_threshold': 0.2, 'num_iterations': 100}
+    if enable_ransac:
+        if ransac_params is None:
+            ransac_params = {'dist_threshold': 0.08, 'num_iterations': 100}
 
-    ground_msg, obstacles_msg = ransac_ground_segmentation(
-        filtered_msg,
-        dist_threshold=ransac_params["dist_threshold"],
-        num_iterations=ransac_params["num_iterations"],
-    )
+        ground_msg, obstacles_msg = ransac_ground_segmentation(
+            filtered_msg,
+            dist_threshold=ransac_params["dist_threshold"],
+            num_iterations=ransac_params["num_iterations"],
+        )
+    else:
+        ground_msg = filtered_msg
+        obstacles_msg = filtered_msg
 
     return filtered_msg, ground_msg, obstacles_msg, stage_counts
 
@@ -76,11 +81,12 @@ def run_preprocessing_pipeline(
     msg: PointCloud2,
     roi: dict[str, float] | None = None,
     ransac_params: dict[str, float] | None = None,
-    voxel_size: float = 0.1,
+    voxel_size: float = 0.03,
     enable_nan_filter: bool = True,
     enable_voxel_filter: bool = True,
     enable_roi_filter: bool = True,
     enable_outlier_filter: bool = True,
+    enable_ransac: bool = True, 
     outlier_mean_k: int = 30,
     outlier_threshold: float = 2.0,
 ) -> tuple[PointCloud2, PointCloud2, PointCloud2]:
@@ -96,6 +102,7 @@ def run_preprocessing_pipeline(
         enable_voxel_filter=enable_voxel_filter,
         enable_roi_filter=enable_roi_filter,
         enable_outlier_filter=enable_outlier_filter,
+        enable_ransac=enable_ransac,
         outlier_mean_k=outlier_mean_k,
         outlier_threshold=outlier_threshold,
     )


### PR DESCRIPTION
**Code Updates:**

- Optimized the Statistical Outlier Removal (SOR) filter by replacing the original O(n²) implementation with a KD-tree based approach, reducing the time complexity to O(n log n).

- Adjusted voxel grid downsampling parameters. The previous configuration removed ~80% of the points, which was too aggressive for downstream processing. Updated parameters preserve more structure while still reducing noise.

**Individual Filter Testing (Gazebo LiDAR):**
All filters were tested independently using live LiDAR data from the Gazebo simulation:

- NaN filter:
16384 → 8192 (50% removed)
Expected behavior due to invalid LiDAR returns.
- Voxel filter (0.03 m):
16384 → ~6690 (~59% removed)
Provides moderate downsampling while preserving scene structure.
- ROI filter:
16384 → 7168 (56.25% removed)
Correctly limits points to the defined spatial bounds.
- SOR filter:
16384 → ~7993 (~51% removed)
Removes isolated noise points; now runs significantly faster with KD-tree optimization.
- RANSAC only:
16384 → 16384 (no reduction)
Expected behavior since RANSAC segments the cloud into ground and obstacles without filtering the total count.